### PR TITLE
Add ID field to WorldObjects #41

### DIFF
--- a/src/AutomatedCar/Models/World.cs
+++ b/src/AutomatedCar/Models/World.cs
@@ -19,6 +19,7 @@
         // private static readonly System.Lazy<World> lazySingleton = new System.Lazy<World> (() => new World());
         // public static World Instance { get { return lazySingleton.Value; } }
 
+        private int lastId = 0;
         private int controlledCarPointer = 0;
         private DebugStatus debugStatus = new DebugStatus();
         private ObservableCollection<AutomatedCar> controlledCars = new ();
@@ -30,7 +31,7 @@
         public AutomatedCar ControlledCar
         {
             get => this.controlledCars[this.controlledCarPointer];
-            
+
         }
         public int ControlledCarPointer
         {
@@ -41,6 +42,12 @@
                 this.RaisePropertyChanged("ControlledCar");
             }
         }
+        public int GetNextId()
+        {
+            this.lastId++;
+            return this.lastId;
+        }
+
         public void AddControlledCar(AutomatedCar controlledCar)
         {
             this.controlledCars.Add(controlledCar);
@@ -72,7 +79,7 @@
             {
                this.ControlledCarPointer = this.controlledCars.Count - 1;
             }
-            
+
             controlledCars[controlledCarPointer].InFocus = true;
             this.RaisePropertyChanged("ControlledCar");
         }
@@ -80,7 +87,7 @@
         public int Width { get; set; }
 
         public int Height { get; set; }
-        
+
         public DebugStatus DebugStatus
         {
             get => this.debugStatus;

--- a/src/AutomatedCar/Models/WorldObject.cs
+++ b/src/AutomatedCar/Models/WorldObject.cs
@@ -7,6 +7,7 @@ namespace AutomatedCar.Models
 
     public class WorldObject : ReactiveObject, IWorldObject
     {
+        private int id;
         private int x;
         private int y;
 
@@ -20,6 +21,7 @@ namespace AutomatedCar.Models
             this.ZIndex = zindex;
             this.Collideable = collideable;
             this.WorldObjectType = worldObjectType;
+            this.Id = World.Instance.GetNextId();
         }
 
         public int ZIndex { get; set; }
@@ -35,6 +37,8 @@ namespace AutomatedCar.Models
             get => this.x;
             set => this.RaiseAndSetIfChanged(ref this.x, value);
         }
+
+        public int Id { get; private set; }
 
         public int Y
         {


### PR DESCRIPTION
A megoldás alapja, hogy a World mint singleton nyilvántartja az utolsó kiosztott ID-t, majd egy WorldObject a példányosításakor megkapja az utolsó+1-es ID-t, az erre szolgáló getNextId metódus pedig értelemszerűen növeli a számlálót.

WorldObject elvileg nem kerülhet eltávolításra a World-ből, de még ha ez meg is történne, akkor sem kellene semmit kezdeni az ID-jéval, egy ID-t többet semmi más nem kaphat meg.

Ez a nagyon egyszerű megoldás nincs felkészítve arra az esetre, hogy ha több szálon akarna valaki világobjektumokat létrehozni, de normál körülmények között erre nem kerülhet sor (én legalábbis nem látok rá reális felhasználói esetet). A világ benépesítése (ideértve mind a statikus, mind a  dinamikus objektumokat) a program elején (egy szálon) fut le, így az ID növeléshez nem szükséges lock-olni.

@SzFMV2021-Osz/team-a2 Ha bármi kifogás merülne fel, vagy nem így gondoltátok, akkor jelezzétek.

close #41